### PR TITLE
Fix for lvl 8 boss, addition of missing rupee secret

### DIFF
--- a/locations/dungeons.json
+++ b/locations/dungeons.json
@@ -2039,7 +2039,7 @@
             {
                 "name": "Gleeok",
                 "access_rules": [
-                    "gleeok_weapons, bomb"                       
+                    "$gleeok_weapons, bomb"                       
                 ],
                 "sections": [
                     {

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -2317,6 +2317,25 @@
                 ]
             },
             {
+                "name": "Secret Rupee 14",
+                "chest_unopened_img": "images/items/rupee.png",
+                "chest_opened_img": "images/items/rupee_gray.png",
+                "sections": [
+                    {
+                        "item_count": 1
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "overworld",
+                        "x": 2263,
+                        "y": 744,
+                        "size": 30,
+                        "border_thickness": 6
+                    }
+                ]
+            },
+            {
                 "name": "Rupee Minigame (South)",
                 "chest_unopened_img": "images/items/rupee.png",
                 "chest_opened_img": "images/items/rupee_gray.png",


### PR DESCRIPTION
The access rules for the lvl 8 Gleeok had a typo, and I added the rupee secret that is in a bush on the screen SE of lvl 1.