### PR TITLE
Fix for lvl 4 gleeok access rule

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1127,7 +1127,7 @@
                     {
                         "name": "Gleeok",
                         "access_rules": [
-                            "$gleeok_weapon, ladder"
+                            "$gleeok_weapons, ladder"
                         ],
                         "item_count": 1
                     },


### PR DESCRIPTION
Found the lvl 4 gleeok issue that was reported, it was in locations and not dungeons.