### PR TITLE
Fix for gleeok access rules on overworld tracker

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1127,7 +1127,7 @@
                     {
                         "name": "Gleeok",
                         "access_rules": [
-                            "$gleeok_weapon, ladder"
+                            "$gleeok_weapons, ladder"
                         ],
                         "item_count": 1
                     },

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1677,7 +1677,7 @@
                     {
                         "name": "Gleeok",
                         "access_rules": [
-                            "$gleeok_weapon, bomb"                       
+                            "$gleeok_weapons, bomb"                       
                         ],
                         "item_count": 1
                     },


### PR DESCRIPTION
I was only looking at the dungeons previously, missed these overworld ones