### PR TITLE
Access rules round up

### DIFF
--- a/locations/dungeons.json
+++ b/locations/dungeons.json
@@ -627,7 +627,7 @@
             {
                 "name": "Keese North",
                 "access_rules": [
-                    "$weapons"                      
+                    "$weapons, bomb, ladder"                      
                 ],
                 "visibility_rules": [
                     "pooltrue"
@@ -1000,7 +1000,7 @@
             {
                 "name": "Recorder",
                 "access_rules": [
-                    "$weapons"                        
+                    "$weapons, bomb"                        
                 ],
                 "sections": [
                     {
@@ -1038,7 +1038,7 @@
             {
                 "name": "Compass",
                 "access_rules": [
-                    "$weapons, ladder, bomb"                        
+                    "$weapons, ladder"                        
                 ],
                 "sections": [
                     {
@@ -1057,7 +1057,7 @@
             {
                 "name": "Digdogger",
                 "access_rules": [
-                    "$weapons, ladder, bomb, flute"                       
+                    "$weapons, ladder, flute"                       
                 ],
                 "sections": [
                     {
@@ -1076,7 +1076,7 @@
             {
                 "name": "Triforce",
                 "access_rules": [
-                    "$weapons, ladder, bomb, flute"                        
+                    "$weapons, ladder, flute"                        
                 ],
                 "sections": [
                     {
@@ -1095,7 +1095,7 @@
             {
                 "name": "Keese North",
                 "access_rules": [
-                    "$weapons,ladder"                       
+                    "$weapons, ladder, bomb"                       
                 ],
                 "visibility_rules": [
                     "pooltrue"
@@ -1117,7 +1117,7 @@
             {
                 "name": "Gibdos North",
                 "access_rules": [
-                    "$weapons, ladder, bomb"                         
+                    "$weapons, ladder"                         
                 ],
                 "visibility_rules": [
                     "pooltrue"
@@ -1139,7 +1139,7 @@
             {
                 "name": "Gibdos Central",
                 "access_rules": [
-                    "$weapons, ladder, bomb"                         
+                    "$weapons, ladder"                         
                 ],
                 "visibility_rules": [
                     "pooltrue"
@@ -1205,7 +1205,7 @@
             {
                 "name": "Gibdos, Keese, and Pols Voice",
                 "access_rules": [
-                    "$weapons, ladder, bomb"
+                    "$weapons, ladder"
                 ],
                 "visibility_rules": [
                     "pooltrue"
@@ -1249,7 +1249,7 @@
             {
                 "name": "Gibdos",
                 "access_rules": [
-                    "$weapons, ladder", "$weapons,bomb"                         
+                    "$weapons, bomb"                         
                 ],
                 "visibility_rules": [
                     "pooltrue"
@@ -1293,7 +1293,7 @@
             {
                 "name": "Zols (Rupee)",
                 "access_rules": [
-                    "$weapons, ladder, bomb"                         
+                    "$weapons, ladder"                         
                 ],
                 "visibility_rules": [
                     "pooltrue"

--- a/locations/dungeons.json
+++ b/locations/dungeons.json
@@ -2400,7 +2400,7 @@
             {
                 "name": "Compass",
                 "access_rules": [
-                    "bomb,$fire"                       
+                    "bomb"                       
                 ],
                 "sections": [
                     {
@@ -2444,7 +2444,7 @@
                     "pooltrue"
                 ],
                 "access_rules": [
-                    "ladder,bomb"                       
+                    "ladder"                       
                 ],
                 "sections": [
                     {
@@ -2642,7 +2642,7 @@
                     "pooltrue"
                 ],
                 "access_rules": [
-                    "bomb,$fire"                       
+                    "bomb"                       
                 ],
                 "sections": [
                     {
@@ -2664,7 +2664,7 @@
                     "pooltrue"
                 ],
                 "access_rules": [
-                    "bomb,$fire"                       
+                    "bomb"                       
                 ],
                 "sections": [
                     {
@@ -2768,7 +2768,7 @@
             {
                 "name": "Ganon",
                 "access_rules": [
-                    "bomb,[ladder],$fire,bow,arrow2"                       
+                    "bomb,bow,arrow2"                       
                 ],
                 "sections": [
                     {
@@ -2787,7 +2787,7 @@
             {
                 "name": "Zelda",
                 "access_rules": [
-                    "bomb,[ladder],$fire,bow,arrow2"                       
+                    "bomb,bow,arrow2"                       
                 ],
                 "sections": [
                     {

--- a/locations/dungeons.json
+++ b/locations/dungeons.json
@@ -885,7 +885,7 @@
             {
                 "name": "Triforce",
                 "access_rules": [
-                    "$weapons, ladder"                        
+                    "$gleeok_weapons, ladder"                        
                 ],
                 "sections": [
                     {
@@ -2058,7 +2058,7 @@
             {
                 "name": "Triforce",
                 "access_rules": [
-                    "bomb"                       
+                    "$gleeok_weapons, bomb"                       
                 ],
                 "sections": [
                     {

--- a/locations/dungeons.json
+++ b/locations/dungeons.json
@@ -252,6 +252,7 @@
     },
     {
         "name": "Moon (D2)",
+        "access_rules": ["[$defense|1]"],
         "children": [
             {
                 "name": "Magical Boomerang",
@@ -506,6 +507,7 @@
     },
     {
         "name": "Manji (D3)",
+        "access_rules": ["[$defense|2]"],
         "children": [
             {
                 "name": "Raft",
@@ -804,7 +806,7 @@
     },
     {
         "name": "Snake (D4)",
-        "access_rules": ["raft,[$fire]","flute,[$fire]"],
+        "access_rules": ["raft,[$fire],[$defense|3]","flute,[$fire],[$defense|3]"],
         "children": [
             {
                 "name": "Stepladder",
@@ -994,7 +996,7 @@
     {
         "name": "Lizard (D5)",
         "access_rules": [
-            "[ladder],[$fire]"
+            "[ladder],[$fire],[$defense|4]"
         ],
         "children": [
             {
@@ -1317,7 +1319,7 @@
     {
         "name": "Dragon (D6)",
         "access_rules": [
-            "$weapons,[ladder],[$fire]"                        
+            "$weapons,[ladder],[$fire],[$defense|5]"                        
         ],
         "children": [
             {
@@ -1555,7 +1557,7 @@
     {
         "name": "Demon (D7)",
         "access_rules": [
-            "$weapons, flute, [$fire], [ladder]"                        
+            "$weapons, flute, [$fire], [ladder], [$defense|6]"                        
         ],
         "children": [
             {
@@ -1960,7 +1962,7 @@
     {
         "name": "Lion (D8)",
         "access_rules": [
-            "$weapons, $fire, [ladder]"                     
+            "$weapons, $fire, [ladder], [$defense|7]"                     
         ],
         "children": [
             {
@@ -2337,7 +2339,7 @@
     {
         "name": "Death Mountain (D9)",
         "access_rules": [
-            "$weapons, triforce:8, [$fire], [ladder]"                     
+            "$weapons, triforce:8, [$fire], [ladder], [$defense|8]"                     
         ],
         "children": [
             {

--- a/locations/dungeons.json
+++ b/locations/dungeons.json
@@ -2768,7 +2768,7 @@
             {
                 "name": "Ganon",
                 "access_rules": [
-                    "bomb,ladder,$fire,bow,arrow2"                       
+                    "bomb,[ladder],$fire,bow,arrow2"                       
                 ],
                 "sections": [
                     {
@@ -2787,7 +2787,7 @@
             {
                 "name": "Zelda",
                 "access_rules": [
-                    "bomb,ladder,$fire,bow,arrow2"                       
+                    "bomb,[ladder],$fire,bow,arrow2"                       
                 ],
                 "sections": [
                     {

--- a/locations/dungeons.json
+++ b/locations/dungeons.json
@@ -1205,7 +1205,7 @@
             {
                 "name": "Gibdos, Keese, and Pols Voice",
                 "access_rules": [
-                    "sword,ladder,bomb","sword2,ladder,bomb","sword3,ladder,bomb","bow,arrow,ladder,bomb","bow,arrow2,ladder,bomb"                   
+                    "$weapons, ladder, bomb"
                 ],
                 "visibility_rules": [
                     "pooltrue"

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -847,6 +847,7 @@
             },
             {
                 "name": "Moon (D2)",
+                "access_rules": ["[$defense|1]"],
                 "sections": [
                     {
                         "name": "Key Drop (Ropes West)",
@@ -964,6 +965,7 @@
             },
             {
                 "name": "Manji (D3)",
+                "access_rules": ["[$defense|2]"],
                 "sections": [
                     {
                         "name": "Key Drop (Zols Entrance)",
@@ -1101,7 +1103,7 @@
             },
             {
                 "name": "Snake (D4)",
-                "access_rules": ["raft,[$fire]","flute,[$fire]"],
+                "access_rules": ["raft,[$fire],[$defense|3]","flute,[$fire],[$defense|3]"],
                 "sections": [
                     {
                         "name": "Stepladder",
@@ -1190,7 +1192,7 @@
             {
                 "name": "Lizard (D5)",
                 "access_rules": [
-                    "[ladder],[$fire]"
+                    "[ladder],[$fire],[$defense|4]"
                 ],
                 "sections": [
                     {
@@ -1340,7 +1342,7 @@
             {
                 "name": "Dragon (D6)",
                 "access_rules": [
-                    "[ladder],[$fire]"
+                    "[ladder],[$fire],[$defense|5]"
                 ],
                 "sections": [
                     {
@@ -1462,7 +1464,7 @@
             {
                 "name": "Demon (D7)",
                 "access_rules": [
-                    "$weapons, flute, [$fire], [ladder]"
+                    "$weapons, flute, [$fire], [ladder], [$defense|6]"
                 ],
                 "sections": [
                     {
@@ -1646,7 +1648,7 @@
             {
                 "name": "Lion (D8)",
                 "access_rules": [
-                    "$weapons, $fire, [ladder]"
+                    "$weapons, $fire, [ladder], [$defense|7]"
                 ],
                 "sections": [
                     {
@@ -1814,7 +1816,7 @@
             {
                 "name": "Death Mountain (D9)",
                 "access_rules": [
-                    "$weapons, triforce:8, [$fire], [ladder]"
+                    "$weapons, triforce:8, [$fire], [ladder], [$defense|8]"
                 ],
                 "sections": [
                     {

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -26,3 +26,7 @@ end
 function arrows()
   return has("arrow") or has("arrow2")
 end
+
+function defense(hearts)
+  return has("heart", hearts) or (has("bluering") and has("heart", hearts / 2)) or (has("redring") and has("heart", hearts / 4))
+end


### PR DESCRIPTION
* Fix for triforces behind gleeoks showing as accessible when the gleeoks can't be killed (LadyBunne)
* Fix for level 5 "Gibdos, Keese, and Pols Voice" check, this is freestanding and can be gotten with any $weapon (LadyBunne)
* Fix for Gannon and Zelda stepladder requirement, there is a path that does not require this (SapphireBlaze)
* Level 5 bomb logic changes to match AP logic
    * There were a few checks that require bombs and the path to the boss does not require bombs
* Level 9 access rules
    * Fire is optional in all rooms
    * Removed a bomb check that does not require it